### PR TITLE
H5FS support

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,18 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+numpy = "*"
+zarr = "*"
+pillow = "*"
+tk = "*"
+ttkthemes = "*"
+tifffile = "*"
+h5py = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,218 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "5783e2bf797690d0d08275ac94c86a939d2d5ebbe40dc7ccf3d0a87d57499b10"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "asciitree": {
+            "hashes": [
+                "sha256:4aa4b9b649f85e3fcb343363d97564aa1fb62e249677f2e18a96765145cc0f6e"
+            ],
+            "version": "==0.3.3"
+        },
+        "fasteners": {
+            "hashes": [
+                "sha256:758819cb5d94cdedf4e836988b74de396ceacb8e2794d21f82d131fd9ee77237",
+                "sha256:b4f37c3ac52d8a445af3a66bce57b33b5e90b97c696b7b984f530cf8f0ded09c"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.19"
+        },
+        "h5py": {
+            "hashes": [
+                "sha256:012ab448590e3c4f5a8dd0f3533255bc57f80629bf7c5054cf4c87b30085063c",
+                "sha256:212bb997a91e6a895ce5e2f365ba764debeaef5d2dca5c6fb7098d66607adf99",
+                "sha256:2381e98af081b6df7f6db300cd88f88e740649d77736e4b53db522d8874bf2dc",
+                "sha256:2c8e4fda19eb769e9a678592e67eaec3a2f069f7570c82d2da909c077aa94339",
+                "sha256:3074ec45d3dc6e178c6f96834cf8108bf4a60ccb5ab044e16909580352010a97",
+                "sha256:3c97d03f87f215e7759a354460fb4b0d0f27001450b18b23e556e7856a0b21c3",
+                "sha256:43a61b2c2ad65b1fabc28802d133eed34debcc2c8b420cb213d3d4ef4d3e2229",
+                "sha256:492305a074327e8d2513011fa9fffeb54ecb28a04ca4c4227d7e1e9616d35641",
+                "sha256:5dfc65ac21fa2f630323c92453cadbe8d4f504726ec42f6a56cf80c2f90d6c52",
+                "sha256:667fe23ab33d5a8a6b77970b229e14ae3bb84e4ea3382cc08567a02e1499eedd",
+                "sha256:6c013d2e79c00f28ffd0cc24e68665ea03ae9069e167087b2adb5727d2736a52",
+                "sha256:781a24263c1270a62cd67be59f293e62b76acfcc207afa6384961762bb88ea03",
+                "sha256:86df4c2de68257b8539a18646ceccdcf2c1ce6b1768ada16c8dcfb489eafae20",
+                "sha256:90286b79abd085e4e65e07c1bd7ee65a0f15818ea107f44b175d2dfe1a4674b7",
+                "sha256:92273ce69ae4983dadb898fd4d3bea5eb90820df953b401282ee69ad648df684",
+                "sha256:93dd840bd675787fc0b016f7a05fc6efe37312a08849d9dd4053fd0377b1357f",
+                "sha256:9450464b458cca2c86252b624279115dcaa7260a40d3cb1594bf2b410a2bd1a3",
+                "sha256:ae2f0201c950059676455daf92700eeb57dcf5caaf71b9e1328e6e6593601770",
+                "sha256:aece0e2e1ed2aab076c41802e50a0c3e5ef8816d60ece39107d68717d4559824",
+                "sha256:b963fb772964fc1d1563c57e4e2e874022ce11f75ddc6df1a626f42bd49ab99f",
+                "sha256:ba9ab36be991119a3ff32d0c7cbe5faf9b8d2375b5278b2aea64effbeba66039",
+                "sha256:d4682b94fd36ab217352be438abd44c8f357c5449b8995e63886b431d260f3d3",
+                "sha256:d93adc48ceeb33347eb24a634fb787efc7ae4644e6ea4ba733d099605045c049",
+                "sha256:f42e6c30698b520f0295d70157c4e202a9e402406f50dc08f5a7bc416b24e52d",
+                "sha256:fd6f6d1384a9f491732cee233b99cd4bfd6e838a8815cc86722f9d2ee64032af"
+            ],
+            "index": "pypi",
+            "version": "==3.10.0"
+        },
+        "numcodecs": {
+            "hashes": [
+                "sha256:05d91a433733e7eef268d7e80ec226a0232da244289614a8f3826901aec1098e",
+                "sha256:0e79bf9d1d37199ac00a60ff3adb64757523291d19d03116832e600cac391c51",
+                "sha256:135b2d47563f7b9dc5ee6ce3d1b81b0f1397f69309e909f1a35bb0f7c553d45e",
+                "sha256:21d8267bd4313f4d16f5b6287731d4c8ebdab236038f29ad1b0e93c9b2ca64ee",
+                "sha256:29dfb195f835a55c4d490fb097aac8c1bcb96c54cf1b037d9218492c95e9d8c5",
+                "sha256:2f1ba2f4af3fd3ba65b1bcffb717fe65efe101a50a91c368f79f3101dbb1e243",
+                "sha256:2f84df6b8693206365a5b37c005bfa9d1be486122bde683a7b6446af4b75d862",
+                "sha256:2fbb12a6a1abe95926f25c65e283762d63a9bf9e43c0de2c6a1a798347dfcb40",
+                "sha256:760627780a8b6afdb7f942f2a0ddaf4e31d3d7eea1d8498cf0fd3204a33c4618",
+                "sha256:82d7107f80f9307235cb7e74719292d101c7ea1e393fe628817f0d635b7384f5",
+                "sha256:941b7446b68cf79f089bcfe92edaa3b154533dcbcd82474f994b28f2eedb1c60",
+                "sha256:a191a8e347ecd016e5c357f2bf41fbcb026f6ffe78fff50c77ab12e96701d155",
+                "sha256:abff3554a6892a89aacf7b642a044e4535499edf07aeae2f2e6e8fc08c9ba07f",
+                "sha256:c17687b1fd1fef68af616bc83f896035d24e40e04e91e7e6dae56379eb59fe33",
+                "sha256:c258bd1d3dfa75a9b708540d23b2da43d63607f9df76dfa0309a7597d1de3b73",
+                "sha256:caf1a1e6678aab9c1e29d2109b299f7a467bd4d4c34235b1f0e082167846b88f",
+                "sha256:d37f628fe92b3699e65831d5733feca74d2e33b50ef29118ffd41c13c677210e",
+                "sha256:e04649ea504aff858dbe294631f098fbfd671baf58bfc04fc48d746554c05d67",
+                "sha256:eeaf42768910f1c6eebf6c1bb00160728e62c9343df9e2e315dc9fe12e3f6071",
+                "sha256:ef964d4860d3e6b38df0633caf3e51dc850a6293fd8e93240473642681d95136",
+                "sha256:f2207871868b2464dc11c513965fd99b958a9d7cde2629be7b2dc84fdaab013b"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.12.1"
+        },
+        "numpy": {
+            "hashes": [
+                "sha256:04640dab83f7c6c85abf9cd729c5b65f1ebd0ccf9de90b270cd61935eef0197f",
+                "sha256:1452241c290f3e2a312c137a9999cdbf63f78864d63c79039bda65ee86943f61",
+                "sha256:222e40d0e2548690405b0b3c7b21d1169117391c2e82c378467ef9ab4c8f0da7",
+                "sha256:2541312fbf09977f3b3ad449c4e5f4bb55d0dbf79226d7724211acc905049400",
+                "sha256:31f13e25b4e304632a4619d0e0777662c2ffea99fcae2029556b17d8ff958aef",
+                "sha256:4602244f345453db537be5314d3983dbf5834a9701b7723ec28923e2889e0bb2",
+                "sha256:4979217d7de511a8d57f4b4b5b2b965f707768440c17cb70fbf254c4b225238d",
+                "sha256:4c21decb6ea94057331e111a5bed9a79d335658c27ce2adb580fb4d54f2ad9bc",
+                "sha256:6620c0acd41dbcb368610bb2f4d83145674040025e5536954782467100aa8835",
+                "sha256:692f2e0f55794943c5bfff12b3f56f99af76f902fc47487bdfe97856de51a706",
+                "sha256:7215847ce88a85ce39baf9e89070cb860c98fdddacbaa6c0da3ffb31b3350bd5",
+                "sha256:79fc682a374c4a8ed08b331bef9c5f582585d1048fa6d80bc6c35bc384eee9b4",
+                "sha256:7ffe43c74893dbf38c2b0a1f5428760a1a9c98285553c89e12d70a96a7f3a4d6",
+                "sha256:80f5e3a4e498641401868df4208b74581206afbee7cf7b8329daae82676d9463",
+                "sha256:95f7ac6540e95bc440ad77f56e520da5bf877f87dca58bd095288dce8940532a",
+                "sha256:9667575fb6d13c95f1b36aca12c5ee3356bf001b714fc354eb5465ce1609e62f",
+                "sha256:a5425b114831d1e77e4b5d812b69d11d962e104095a5b9c3b641a218abcc050e",
+                "sha256:b4bea75e47d9586d31e892a7401f76e909712a0fd510f58f5337bea9572c571e",
+                "sha256:b7b1fc9864d7d39e28f41d089bfd6353cb5f27ecd9905348c24187a768c79694",
+                "sha256:befe2bf740fd8373cf56149a5c23a0f601e82869598d41f8e188a0e9869926f8",
+                "sha256:c0bfb52d2169d58c1cdb8cc1f16989101639b34c7d3ce60ed70b19c63eba0b64",
+                "sha256:d11efb4dbecbdf22508d55e48d9c8384db795e1b7b51ea735289ff96613ff74d",
+                "sha256:dd80e219fd4c71fc3699fc1dadac5dcf4fd882bfc6f7ec53d30fa197b8ee22dc",
+                "sha256:e2926dac25b313635e4d6cf4dc4e51c8c0ebfed60b801c799ffc4c32bf3d1254",
+                "sha256:e98f220aa76ca2a977fe435f5b04d7b3470c0a2e6312907b37ba6068f26787f2",
+                "sha256:ed094d4f0c177b1b8e7aa9cba7d6ceed51c0e569a5318ac0ca9a090680a6a1b1",
+                "sha256:f136bab9c2cfd8da131132c2cf6cc27331dd6fae65f95f69dcd4ae3c3639c810",
+                "sha256:f3a86ed21e4f87050382c7bc96571755193c4c1392490744ac73d660e8f564a9"
+            ],
+            "index": "pypi",
+            "version": "==1.24.4"
+        },
+        "pillow": {
+            "hashes": [
+                "sha256:00f438bb841382b15d7deb9a05cc946ee0f2c352653c7aa659e75e592f6fa17d",
+                "sha256:0248f86b3ea061e67817c47ecbe82c23f9dd5d5226200eb9090b3873d3ca32de",
+                "sha256:04f6f6149f266a100374ca3cc368b67fb27c4af9f1cc8cb6306d849dcdf12616",
+                "sha256:062a1610e3bc258bff2328ec43f34244fcec972ee0717200cb1425214fe5b839",
+                "sha256:0a026c188be3b443916179f5d04548092e253beb0c3e2ee0a4e2cdad72f66099",
+                "sha256:0f7c276c05a9767e877a0b4c5050c8bee6a6d960d7f0c11ebda6b99746068c2a",
+                "sha256:1a8413794b4ad9719346cd9306118450b7b00d9a15846451549314a58ac42219",
+                "sha256:1ab05f3db77e98f93964697c8efc49c7954b08dd61cff526b7f2531a22410106",
+                "sha256:1c3ac5423c8c1da5928aa12c6e258921956757d976405e9467c5f39d1d577a4b",
+                "sha256:1c41d960babf951e01a49c9746f92c5a7e0d939d1652d7ba30f6b3090f27e412",
+                "sha256:1fafabe50a6977ac70dfe829b2d5735fd54e190ab55259ec8aea4aaea412fa0b",
+                "sha256:1fb29c07478e6c06a46b867e43b0bcdb241b44cc52be9bc25ce5944eed4648e7",
+                "sha256:24fadc71218ad2b8ffe437b54876c9382b4a29e030a05a9879f615091f42ffc2",
+                "sha256:2cdc65a46e74514ce742c2013cd4a2d12e8553e3a2563c64879f7c7e4d28bce7",
+                "sha256:2ef6721c97894a7aa77723740a09547197533146fba8355e86d6d9a4a1056b14",
+                "sha256:3b834f4b16173e5b92ab6566f0473bfb09f939ba14b23b8da1f54fa63e4b623f",
+                "sha256:3d929a19f5469b3f4df33a3df2983db070ebb2088a1e145e18facbc28cae5b27",
+                "sha256:41f67248d92a5e0a2076d3517d8d4b1e41a97e2df10eb8f93106c89107f38b57",
+                "sha256:47e5bf85b80abc03be7455c95b6d6e4896a62f6541c1f2ce77a7d2bb832af262",
+                "sha256:4d0152565c6aa6ebbfb1e5d8624140a440f2b99bf7afaafbdbf6430426497f28",
+                "sha256:50d08cd0a2ecd2a8657bd3d82c71efd5a58edb04d9308185d66c3a5a5bed9610",
+                "sha256:61f1a9d247317fa08a308daaa8ee7b3f760ab1809ca2da14ecc88ae4257d6172",
+                "sha256:6932a7652464746fcb484f7fc3618e6503d2066d853f68a4bd97193a3996e273",
+                "sha256:7a7e3daa202beb61821c06d2517428e8e7c1aab08943e92ec9e5755c2fc9ba5e",
+                "sha256:7dbaa3c7de82ef37e7708521be41db5565004258ca76945ad74a8e998c30af8d",
+                "sha256:7df5608bc38bd37ef585ae9c38c9cd46d7c81498f086915b0f97255ea60c2818",
+                "sha256:806abdd8249ba3953c33742506fe414880bad78ac25cc9a9b1c6ae97bedd573f",
+                "sha256:883f216eac8712b83a63f41b76ddfb7b2afab1b74abbb413c5df6680f071a6b9",
+                "sha256:912e3812a1dbbc834da2b32299b124b5ddcb664ed354916fd1ed6f193f0e2d01",
+                "sha256:937bdc5a7f5343d1c97dc98149a0be7eb9704e937fe3dc7140e229ae4fc572a7",
+                "sha256:9882a7451c680c12f232a422730f986a1fcd808da0fd428f08b671237237d651",
+                "sha256:9a92109192b360634a4489c0c756364c0c3a2992906752165ecb50544c251312",
+                "sha256:9d7bc666bd8c5a4225e7ac71f2f9d12466ec555e89092728ea0f5c0c2422ea80",
+                "sha256:a5f63b5a68daedc54c7c3464508d8c12075e56dcfbd42f8c1bf40169061ae666",
+                "sha256:a646e48de237d860c36e0db37ecaecaa3619e6f3e9d5319e527ccbc8151df061",
+                "sha256:a89b8312d51715b510a4fe9fc13686283f376cfd5abca8cd1c65e4c76e21081b",
+                "sha256:a92386125e9ee90381c3369f57a2a50fa9e6aa8b1cf1d9c4b200d41a7dd8e992",
+                "sha256:ae88931f93214777c7a3aa0a8f92a683f83ecde27f65a45f95f22d289a69e593",
+                "sha256:afc8eef765d948543a4775f00b7b8c079b3321d6b675dde0d02afa2ee23000b4",
+                "sha256:b0eb01ca85b2361b09480784a7931fc648ed8b7836f01fb9241141b968feb1db",
+                "sha256:b1c25762197144e211efb5f4e8ad656f36c8d214d390585d1d21281f46d556ba",
+                "sha256:b4005fee46ed9be0b8fb42be0c20e79411533d1fd58edabebc0dd24626882cfd",
+                "sha256:b920e4d028f6442bea9a75b7491c063f0b9a3972520731ed26c83e254302eb1e",
+                "sha256:baada14941c83079bf84c037e2d8b7506ce201e92e3d2fa0d1303507a8538212",
+                "sha256:bb40c011447712d2e19cc261c82655f75f32cb724788df315ed992a4d65696bb",
+                "sha256:c0949b55eb607898e28eaccb525ab104b2d86542a85c74baf3a6dc24002edec2",
+                "sha256:c9aeea7b63edb7884b031a35305629a7593272b54f429a9869a4f63a1bf04c34",
+                "sha256:cfe96560c6ce2f4c07d6647af2d0f3c54cc33289894ebd88cfbb3bcd5391e256",
+                "sha256:d27b5997bdd2eb9fb199982bb7eb6164db0426904020dc38c10203187ae2ff2f",
+                "sha256:d921bc90b1defa55c9917ca6b6b71430e4286fc9e44c55ead78ca1a9f9eba5f2",
+                "sha256:e6bf8de6c36ed96c86ea3b6e1d5273c53f46ef518a062464cd7ef5dd2cf92e38",
+                "sha256:eaed6977fa73408b7b8a24e8b14e59e1668cfc0f4c40193ea7ced8e210adf996",
+                "sha256:fa1d323703cfdac2036af05191b969b910d8f115cf53093125e4058f62012c9a",
+                "sha256:fe1e26e1ffc38be097f0ba1d0d07fcade2bcfd1d023cda5b29935ae8052bd793"
+            ],
+            "index": "pypi",
+            "version": "==10.1.0"
+        },
+        "tifffile": {
+            "hashes": [
+                "sha256:94dfdec321ace96abbfe872a66cfd824800c099a2db558443453eebc2c11b304",
+                "sha256:c06ec460926d16796eeee249a560bcdddf243daae36ac62af3c84a953cd60b4a"
+            ],
+            "index": "pypi",
+            "version": "==2023.7.10"
+        },
+        "tk": {
+            "hashes": [
+                "sha256:60bc8923d5d35f67f5c6bd93d4f0c49d2048114ec077768f959aef36d4ed97f8",
+                "sha256:703a69ff0d5ba2bd2f7440582ad10160e4a6561595d33457dc6caa79b9bf4930"
+            ],
+            "index": "pypi",
+            "version": "==0.1.0"
+        },
+        "ttkthemes": {
+            "hashes": [
+                "sha256:01daed001f2ff0e4f32832a0d9ea48176c0c505203b030756bdde3bd1bcb21d2"
+            ],
+            "index": "pypi",
+            "version": "==3.2.2"
+        },
+        "zarr": {
+            "hashes": [
+                "sha256:4276cf4b4a653431042cd53ff2282bc4d292a6842411e88529964504fb073286",
+                "sha256:de4882433ccb5b42cc1ec9872b95e64ca3a13581424666b28ed265ad76c7056f"
+            ],
+            "index": "pypi",
+            "version": "==2.16.1"
+        }
+    },
+    "develop": {}
+}

--- a/kintsugi.py
+++ b/kintsugi.py
@@ -180,10 +180,10 @@ class VesuviusKintsugi:
             try:
                 # Load the prediction PNG file
                 loaded_prediction = Image.open(pred_file_path)
-                
+
                 # Convert the image to a NumPy array
                 prediction_data_np = np.array(loaded_prediction)
-                
+
                 # Calculate padding and remove it
                 '''
                 pad0 = (64 - self.voxel_data.shape[1] % 64) # 64 tile size
@@ -215,7 +215,7 @@ class VesuviusKintsugi:
         # File dialog to select mask file
         mask_file_path = filedialog.askdirectory(
             title="Select Label Zarr File")
-            
+
 
         if mask_file_path:
             try:
@@ -262,7 +262,7 @@ class VesuviusKintsugi:
             current_threshold = self.threshold[self.th_layer]
             self.bucket_threshold_var.set(f"{current_threshold}")
             # You may need to adjust this line depending on how the slider is named in your code
-            self.bucket_threshold_slider.set(current_threshold)  
+            self.bucket_threshold_slider.set(current_threshold)
 
             self.update_log(f"Layer {self.th_layer} selected, current threshold is {current_threshold}.")
         except ValueError:
@@ -342,7 +342,7 @@ class VesuviusKintsugi:
 
     def undo_last_action(self):
         if self.history:
-            self.mask_data = self.history.pop() 
+            self.mask_data = self.history.pop()
             self.update_display_slice()
             self.update_log("Last action undone.")
         else:
@@ -378,7 +378,7 @@ class VesuviusKintsugi:
         self.drag_start_x = None
         self.drag_start_y = None
         self.update_display_slice()
-        
+
     def resize_with_aspect(self, image, target_width, target_height, zoom=1):
         original_width, original_height = image.size
         zoomed_width, zoomed_height = int(original_width * zoom), int(original_height * zoom)
@@ -402,18 +402,18 @@ class VesuviusKintsugi:
         self.zoom_level = min(new_width / original_width, new_height / original_height)
 
         return image.resize((new_width, new_height), Image.Resampling.NEAREST)
-    
+
     def update_display_slice(self):
         if self.voxel_data is not None and self.canvas is not None:
             target_width_xy = self.canvas.winfo_width()
             target_height_xy = self.canvas.winfo_height()
-                      
+
             # Convert the current slice to an RGBA image
             if self.show_image:
                 if self.z_index in self.slice_cache:
                     img = self.slice_cache[self.z_index]
                 else:
-                    img = self.prepare_image_slice(self.z_index)           
+                    img = self.prepare_image_slice(self.z_index)
             else:
                 img = Image.new('RGBA', (target_width_xy, target_height_xy))
 
@@ -472,8 +472,8 @@ class VesuviusKintsugi:
             # Transform the image using the affine matrix
             self.resized_img = img.transform(
                 (target_width_xy, target_height_xy),
-                Image.AFFINE,   
-                affine_inv,   
+                Image.AFFINE,
+                affine_inv,
                 Image.Resampling.NEAREST
             )
 
@@ -534,7 +534,7 @@ class VesuviusKintsugi:
             img_y = max(0, min(img_y, self.voxel_data.shape[1] - 1))
 
             return self.z_index, img_y, img_x
-    
+
     def color_pixel(self, img_coords):
         z_index, center_y, center_x = img_coords
         if self.voxel_data is not None:
@@ -555,7 +555,7 @@ class VesuviusKintsugi:
                             target_mask[z_index, y, x] = mask_value
             self.update_display_slice()
 
-    
+
     def update_pencil_size(self, val):
         self.pencil_size = int(float(val))
         self.pencil_size_var.set(f"{self.pencil_size}")
@@ -576,7 +576,7 @@ class VesuviusKintsugi:
             self.pencil_cursor = self.canvas.create_oval(event.x - radius, event.y - radius, event.x + radius, event.y + radius, outline=color, width=2)
         self.click_coordinates = (self.z_index, event.y, event.x)
         self.update_info_display()
-            
+
     def scroll_or_zoom(self, event):
         # Adjust for different platforms
         ctrl_pressed = False
@@ -800,10 +800,10 @@ Created by Dr. Giorgio Angelotti, Vesuvius Kintsugi is designed for efficient 3D
         drawing_tools_frame.pack(side=tk.LEFT, padx=5)
 
         # Load and set icons for buttons (icons need to be added)
-        load_icon = PhotoImage(file='./icons/open-64.png') 
+        load_icon = PhotoImage(file='./icons/open-64.png')
         save_icon = PhotoImage(file='./icons/save-64.png')
         prediction_icon = PhotoImage(file='./icons/prediction-64.png')
-        undo_icon = PhotoImage(file='./icons/undo-64.png') 
+        undo_icon = PhotoImage(file='./icons/undo-64.png')
         brush_icon = PhotoImage(file='./icons/brush-64.png')
         eraser_icon = PhotoImage(file='./icons/eraser-64.png')
         bucket_icon = PhotoImage(file='./icons/bucket-64.png')

--- a/kintsugi.py
+++ b/kintsugi.py
@@ -286,7 +286,7 @@ class VesuviusKintsugi:
 
     def flood_fill_3d(self, start_coord):
         self.flood_fill_active = True
-        if self.format == 'zarr':
+        if self.format in ['zarr', 'h5fs']:
             target_color = int(self.voxel_data[start_coord])
         elif self.format == 'tiff':
             z, y, x = start_coord
@@ -305,8 +305,8 @@ class VesuviusKintsugi:
 
             if self.barrier_mask[cz, cy, cx] != 0:
                 continue
-            
-            if self.format == 'zarr':
+
+            if self.format in ['zarr', 'h5fs']:
                 voxel_value = int(self.voxel_data[cz, cy, cx])
                 print(voxel_value)
 


### PR DESCRIPTION
This MR adds:
- `Pipfile` and `Pipfile.lock` for easier installation with `pipenv`
- support for H5FS input files

I had difficulties incorporating this into existing UI, so I sidestepped the problem by using command-line parameters. Arguably, this is even easier to use, as one can switch Kintsugi between different datasets without clicking.

App can now be started like this:
```
$ python kintsugi.py --h5fs-file=/path/to/file.h5 --axes=zxy --roi=3070-3900,2770-3100,1500-2000
```

Region of interest (`--roi`) is specified in original dataset coordinates (and the axes sequence matches dataset too), one must take care not to specify too big a volume, because it all goes into memory.

With `--axes`, one can specify what kind of axes sequence the original dataset has. This will be mapped so that `z` will be zoomable (depth), `x` will be horizontal and `y` will be vertical.

I tried not to change much else... Let me know if you would like something changed, and of course feel free to change anything yourself too. Good luck, and let's read those scrolls!